### PR TITLE
fix: the npm package is missing index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Built files
 *.js
+!index.js
 !binding.js
 *.map
 *.d.ts

--- a/packages/css/lib/index.js
+++ b/packages/css/lib/index.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.minify = void 0;
+const binding = require("./binding");
+async function minify(content, options) {
+  return binding.minify(content, toBuffer(options));
+}
+exports.minify = minify;
+function toBuffer(t) {
+  return Buffer.from(JSON.stringify(t));
+}

--- a/packages/html/lib/index.js
+++ b/packages/html/lib/index.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.minify = void 0;
+const binding = require("./binding");
+async function minify(content, options) {
+  return binding.minify(content, toBuffer(options));
+}
+exports.minify = minify;
+function toBuffer(t) {
+  return Buffer.from(JSON.stringify(t));
+}


### PR DESCRIPTION
When I use `@swc/css`, I find that the package does not contain index.js.